### PR TITLE
test(ofx): Fix some test flakyness

### DIFF
--- a/plugins/exporters/ofx/src/funTest/kotlin/OfxExporterFunTest.kt
+++ b/plugins/exporters/ofx/src/funTest/kotlin/OfxExporterFunTest.kt
@@ -4,7 +4,9 @@ import dev.schuberth.stan.AbstractTextExporterFunTest
 
 import java.time.LocalDateTime
 
+private val DTSERVER = LocalDateTime.now().format(OfxExporter.DATE_FORMATTER)
+
 class OfxExporterFunTest : AbstractTextExporterFunTest(
     OfxExporter(),
-    { replace(Regex("(<DTSERVER>)\\d+"), "$1${LocalDateTime.now().format(OfxExporter.DATE_FORMATTER)}") }
+    { replace(Regex("(<DTSERVER>)\\d+"), "$1$DTSERVER") }
 )


### PR DESCRIPTION
The lambda is evaluated for both expected and actual texts in between which the seconds of time could have changed.